### PR TITLE
Implement new stuff hinted in unittest

### DIFF
--- a/rgbenv
+++ b/rgbenv
@@ -96,12 +96,10 @@ help () {
 checkver () {
 	if [ -z $1 ]; then
 		echo "No version number set!"
-		point_to_available_command
-		exit 1
+		point_to_available_command_and_terminate
 	elif [[ ! $1 =~ [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[A-Za-z0-9_]+)? ]]; then
 		echo "Invalid version number."
-		point_to_available_command
-		exit 1
+		point_to_available_command_and_terminate
 	fi
 }
 
@@ -162,22 +160,26 @@ show_install_instructions () {
 	echo "You can try to install this version by:"
 	echo "    rgbenv install $1"
 }
-point_to_available_command () {
+
+point_to_available_command_and_terminate () {
 	echo
 	echo "To see available versions:"
 	echo "    rgbenv available"
+	exit 1
 }
 
-point_to_available_online () {
+point_to_available_online_and_terminate () {
 	echo
 	echo "Check for installable versions by:"
 	echo "    rgbenv available --online"
+	exit 1
 }
 
-point_to_use () {
+point_to_use_and_terminate () {
 	echo
 	echo "Select a version to use with:"
 	echo "    rgbenv use <version>"
+	exit 1
 }
 
 # --------------- Subcommands -----------------------------------------
@@ -202,6 +204,7 @@ _available () {
 			echo "Then, from that list, install the version you"
 			echo "want using:"
 			echo "    rgbenv install <version>"
+			exit 1
 		else
 			echo "Currently installed versions:"
 			for i in $have_versions; do
@@ -220,7 +223,7 @@ _use () {
 			cat $RGBENV_DEFAULT/version
 		else
 			echo "Use which version?"
-			point_to_available_command
+			point_to_available_command_and_terminate
 		fi
 	else
 		checkver $1;
@@ -249,7 +252,7 @@ _use () {
 		else
 			echo "Version $1 has not been installed yet."
 			show_install_instructions $1
-			point_to_available_command
+			point_to_available_command_and_terminate
 		fi
 	fi
 }
@@ -275,8 +278,7 @@ _install () {
 	local download_link="$RGBDS_DOWNLOAD_BASE$version"
 	if [ -z $version ]; then
 		echo "Which version to install?"
-		point_to_available_online
-		exit 1
+		point_to_available_online_and_terminate
 	fi
 	checkverinstall $version
 	
@@ -292,8 +294,7 @@ _install () {
 	done
 	if [ $got_version -eq 0 ]; then
 		echo "Version $version not found in the releases page."
-		point_to_available_online
-		exit 1
+		point_to_available_online_and_terminate
 	fi
 	
 	# if so, download the tarball and extract it
@@ -325,7 +326,7 @@ _uninstall () {
 	local version=$1
 	if [ -z $version ]; then
 		echo "Which version to uninstall?"
-		point_to_available_command
+		point_to_available_command_and_terminate
 	else
 		checkver $version
 		if [ -d $RGBENV_VERSIONS/$RGBDS_PREFIX$version ]; then
@@ -358,8 +359,7 @@ _exec () {
 		else
 			echo "Version $version is not installed."
 			show_install_instructions $version
-			point_to_available_command
-			exit 1
+			point_to_available_command_and_terminate
 		fi
 	elif [ -f .rgbds-version ]; then
 		local version=$(cat .rgbds-version | tr -d " \t\n\r")
@@ -372,8 +372,7 @@ _exec () {
 		else
 			echo "Version $version is not installed."
 			show_install_instructions $version
-			point_to_available_command
-			exit 1
+			point_to_available_command_and_terminate
 		fi
 	else
 		# when PATH is set properly, this would pretty much be useless
@@ -382,8 +381,7 @@ _exec () {
 			version=$(cat $RGBENV_DEFAULT/version)
 			if [ ! -x $RGBENV_VERSIONS/$RGBDS_PREFIX$version/rgbasm ]; then
 				echo "Version not set."
-				point_to_use
-				exit 1
+				point_to_use_and_terminate
 			else
 				if [ ${#@} -gt 0 ]; then
 					env PATH="$RGBENV_VERSIONS/$RGBDS_PREFIX$version:$PATH" "$@"
@@ -391,8 +389,7 @@ _exec () {
 			fi
 		else
 			echo "Version not set."
-			point_to_use
-			exit 1
+			point_to_use_and_terminate
 		fi
 	fi
 }

--- a/rgbenv
+++ b/rgbenv
@@ -33,13 +33,15 @@ RGBDS_PREFIX="rgbds-"
 # --------------- Var defines -------------------------------------------------
 
 # Set up XDG standard directories (Linux, etc.)
-RGBENV_DEFAULT=${XDG_DATA_HOME:-$HOME/.local/share}/rgbenv/default
-RGBENV_VERSIONS=${XDG_DATA_HOME:-$HOME/.local/share}/rgbenv/versions
+RGBENV_ROOT_SUFFIX="rgbenv"
 
-if [[ ! -d ${XDG_DATA_HOME:-$HOME/.local/share} ]]; then
-	RGBENV_DEFAULT=$HOME/.rgbenv/default
-	RGBENV_VERSIONS=$HOME/.rgbenv/versions
+RGBENV_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/$RGBENV_ROOT_SUFFIX"
+if [[ ! -d "${XDG_DATA_HOME:-$HOME/.local/share}" ]]; then
+	RGBENV_ROOT="$HOME/.$RGBENV_ROOT_SUFFIX"
 fi
+
+RGBENV_DEFAULT="$RGBENV_ROOT/default"
+RGBENV_VERSIONS="$RGBENV_ROOT/versions"
 
 RGBDS_PREFIX_LEN=${#RGBDS_PREFIX}
 
@@ -131,6 +133,27 @@ _remove () {
 			* ) echo "Please answer y or n.";;
 		esac
 	done
+}
+
+offer_to_move () {
+	local has_choice=0
+	echo "XDG_DATA_HOME defined, but there's an existing rgbenv"
+	echo "installation at $HOME/.$RGBENV_ROOT_SUFFIX."
+	echo "Moving the existing installation seems like a good idea:"
+	echo "    $HOME/.$RGBENV_ROOT_SUFFIX -> $RGBENV_ROOT"
+	echo
+	while [ $has_choice -eq 0 ]; do
+		read -p "Would you like to move these directories? [y/n] " choice
+		case $choice in
+			[Yy]* ) move_dirs; has_choice=1; break;;
+			[Nn]* ) has_choice=1; exit;;
+			* ) echo "Please answer y or n.";;
+		esac
+	done
+}
+
+move_dirs () {
+	mv "$HOME/.$RGBENV_ROOT_SUFFIX" "$RGBENV_ROOT"
 }
 
 setup () {
@@ -398,7 +421,11 @@ _exec () {
 
 # Perform setup
 if [ ! -d $RGBENV_DEFAULT ]; then
-	setup
+	if [ -d "$HOME/.$RGBENV_ROOT_SUFFIX" ]; then
+		offer_to_move
+	else
+		setup
+	fi
 fi
 
 # Main program

--- a/tests/init-rgbenv.bats
+++ b/tests/init-rgbenv.bats
@@ -30,14 +30,12 @@ setup() {
 }
 
 @test "if \$XDG_DATA_HOME defined, offer to move ~/.rgbenv there" {
-	skip "Not implemented yet"
-	
 	mkdir $HOME/.rgbenv
 	
 	export XDG_DATA_HOME="$HOME/data"
 	mkdir $XDG_DATA_HOME
 	
-	assert [ ! -d "$XDG_DATA_HOME/rgbenv"]
+	assert [ ! -d "$XDG_DATA_HOME/rgbenv" ]
 	
 	yes | rgbenv # should offer to move the directory there
 	

--- a/tests/install-rgbds.bats
+++ b/tests/install-rgbds.bats
@@ -30,7 +30,6 @@ get_old_version() {
 }
 
 @test "fail on using nonexistent version" {
-	skip "Need to implement the necessary exit-codes"
 	run use_nonexistent_version
 	assert_fail
 }


### PR DESCRIPTION
When `$XDG_DATA_HOME` is defined but `$HOME/.rgbenv` already exists, it'll move the existing installation there
(I'll refactor out the choicer later :/)