### PR TITLE
Add quickstart description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a version manager for [RGBDS](https://github.com/gbdev/rgbds). It is a p
 \* Bash script, at the moment. Compatibility with other shells is not guaranteed.
 
 ## Quickstart (Debian)
+
 ```sh
 sudo apt install -y libpng-dev pkg-config build-essential bison git curl
 sudo curl -o /usr/local/bin/rgbenv https://raw.githubusercontent.com/gbdev/rgbenv/master/rgbenv

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ This is a version manager for [RGBDS](https://github.com/gbdev/rgbds). It is a p
 
 \* Bash script, at the moment. Compatibility with other shells is not guaranteed.
 
+## Quickstart (Debian)
+```sh
+sudo apt install -y libpng-dev pkg-config build-essential bison git curl
+sudo sh -c 'curl https://raw.githubusercontent.com/gbdev/rgbenv/master/rgbenv > /usr/local/bin/rgbenv'
+sudo chmod +x /usr/local/bin/rgbenv
+yes | rgbenv install 0.7.0
+rgbenv use 0.7.0
+echo 'export PATH=$HOME/.local/share/rgbenv/default/bin:$PATH' >> .bashrc
+source .bashrc
+
+rgbasm -V
+```
+
 ## What does it do?
 
 * Installs or uninstalls a specific version of the RGBDS suite.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,39 @@ This is a version manager for [RGBDS](https://github.com/gbdev/rgbds). It is a p
 
 ## Quickstart (Debian)
 
+### 1. Get rgbenv
 ```sh
 sudo apt install -y libpng-dev pkg-config build-essential bison git curl
 sudo curl -o /usr/local/bin/rgbenv https://raw.githubusercontent.com/gbdev/rgbenv/master/rgbenv
 sudo chmod +x /usr/local/bin/rgbenv
-yes | rgbenv install 0.7.0
+```
+
+### 2. Install a version and set it as the default
+```sh
+rgbenv install 0.7.0
 rgbenv use 0.7.0
+```
+
+### 3. Use the default version
+```sh
+rgbenv exec rgbasm -V
+```
+(replace `rgbasm -V` with your desired command)
+
+To use it without `rgbenv exec`…
+```sh
 echo 'export PATH="$HOME/.local/share/rgbenv/default/bin:$PATH"' >> .bashrc
 source .bashrc
-
 rgbasm -V
 ```
+
+### 4. Execute with another version
+```sh
+rgbenv install 0.6.1
+rgbenv exec -v 0.6.1 rgbasm -V
+```
+(replace `rgbasm -V` with your desired command)
+
 
 ## What does it do?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a version manager for [RGBDS](https://github.com/gbdev/rgbds). It is a p
 ## Quickstart (Debian)
 ```sh
 sudo apt install -y libpng-dev pkg-config build-essential bison git curl
-sudo sh -c 'curl https://raw.githubusercontent.com/gbdev/rgbenv/master/rgbenv > /usr/local/bin/rgbenv'
+sudo curl -o /usr/local/bin/rgbenv https://raw.githubusercontent.com/gbdev/rgbenv/master/rgbenv
 sudo chmod +x /usr/local/bin/rgbenv
 yes | rgbenv install 0.7.0
 rgbenv use 0.7.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ sudo curl -o /usr/local/bin/rgbenv https://raw.githubusercontent.com/gbdev/rgben
 sudo chmod +x /usr/local/bin/rgbenv
 yes | rgbenv install 0.7.0
 rgbenv use 0.7.0
-echo 'export PATH=$HOME/.local/share/rgbenv/default/bin:$PATH' >> .bashrc
+echo 'export PATH="$HOME/.local/share/rgbenv/default/bin:$PATH"' >> .bashrc
 source .bashrc
 
 rgbasm -V


### PR DESCRIPTION
It's the one for Debian, for now.

Should address #14 even though it's not "quite" a one-liner, since it also covers installing the dependencies.

Some notes while writing the quickstart:
* Should we be able to select `stable` (latest version) and `devel` (`master`) versions?
* Making the `curl` URL tidier (could be by e.g. making a URL in gbdev.io that redirects to the script)
* Could use a command to print the rgbenv dirs
* Or maybe take inspiration from version managers that have an `eval $(version_manager init)`  command?
* The script can be placed locally, of course, but placing it in `/usr/local/bin` is just a convenience thing (no need to track additional `$PATH` dirs—do we need an additional `install.sh` script?