### PR TITLE
Require bash for rgbenv

### DIFF
--- a/rgbenv
+++ b/rgbenv
@@ -22,27 +22,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Prevent boundless recursion
-if [ -z "${RGBENV_REEXEC_COUNT}" ]; then
-	RGBENV_REEXEC_COUNT=0
-else
-	RGBENV_REEXEC_COUNT=$(expr ${RGBENV_REEXEC_COUNT} + 1)
-fi
-export RGBENV_REEXEC_COUNT
-
-if (command -v bash 2>&1 > /dev/null); then
-	if [ "${SHELL}" = "$(command -v bash)" ]; then
-		if [ "${RGBENV_REEXEC_COUNT}" -gt 1 ]; then
-			exit
-		fi
-	else
-		exec /usr/bin/env bash "${0}" "${@}"
-	fi
-else
+if ! (command -v bash 2>&1 > /dev/null); then
 	echo "Sorry, rgbenv requires bash."
 	exit 1
 fi
 
+if [ "${SHELL}" != "$(command -v bash)" ]; then
+	# Prevent boundless recursion
+	if [ -z "${REEXEC_COUNT}" ]; then
+		RGBENV_REEXEC_COUNT=0
+	else
+		RGBENV_REEXEC_COUNT=$(expr ${RGBENV_REEXEC_COUNT} + 1)
+	fi
+	export RGBENV_REEXEC_COUNT
+	
+	if [ "${RGBENV_REEXEC_COUNT}" -gt 1 ]; then
+		exit
+	fi
+	
+	exec /usr/bin/env bash "${0}" "${@}"
+fi
 
 set -euo pipefail
 

--- a/rgbenv
+++ b/rgbenv
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # SPDX-License-Identifier: MIT
 #
@@ -21,6 +21,30 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+# Prevent boundless recursion
+if [ -z "${RGBENV_REEXEC_COUNT}" ]; then
+	RGBENV_REEXEC_COUNT=0
+else
+	RGBENV_REEXEC_COUNT=$(expr ${RGBENV_REEXEC_COUNT} + 1)
+fi
+export RGBENV_REEXEC_COUNT
+
+if (command -v bash 2>&1 > /dev/null); then
+	if [ "${SHELL}" = "$(command -v bash)" ]; then
+		if [ "${RGBENV_REEXEC_COUNT}" -gt 1 ]; then
+			exit
+		fi
+	else
+		exec /usr/bin/env bash "${0}" "${@}"
+	fi
+else
+	echo "Sorry, rgbenv requires bash."
+	exit 1
+fi
+
+
+set -euo pipefail
 
 # --------------- Constant defines -------------------------------------------------
 


### PR DESCRIPTION
Enforces `bash` to run `rgbenv`. Under `sh`, it first checks for the existence of `bash` on the device, and then re-executes itself under `bash` if it exists.

On slower environments, e.g. Termux, it might cause a slight delay on startup. However it should have trivial effect on the "usual" (PC, etc.) environments.

<hr>

Although `bash` is the most commonly-used shell (especially on Linux), I was concerned about other environments (outside of WIndows with batch files) where that may not be available (see #9).

But I think I want the extra checking facilities that `bash` provides, and honestly POSIX `sh` is a bit too limiting. I'm concerned about Mac OS since I'm  still unable to test that, but I'd like to hear some thoughts on this.