### PR TITLE
Install manpages from selected version

### DIFF
--- a/rgbenv
+++ b/rgbenv
@@ -261,6 +261,14 @@ _use () {
 			done
 			echo
 			
+			# symlink man pages
+			rm -rf "$RGBENV_DEFAULT/man"
+			for i in 1 5 7; do
+				mkdir -p "$RGBENV_DEFAULT/man/man$i"
+				# use find because the pages available and their location depends on version
+				find "$RGBENV_VERSIONS/$RGBDS_PREFIX$1" -type f -name "*.$i" -exec ln -s -t "$RGBENV_DEFAULT/man/man$i" '{}' ';'
+			done
+
 			echo "$1" > "$RGBENV_DEFAULT/version"
 			
 			echo "The default RGBDS has been set to $1."
@@ -286,6 +294,9 @@ _no_use () {
 	fi
 	if [ -d "$RGBENV_DEFAULT/bin" ]; then
 		rm -r "${RGBENV_DEFAULT:?}/bin"
+	fi
+	if [ -d "$RGBENV_DEFAULT/man" ]; then
+		rm -r "${RGBENV_DEFAULT:?}/man"
 	fi
 	echo "Symlinks and version configuration deleted."
 	echo "RGBDS is now managed by the system."


### PR DESCRIPTION
Changes rgbenv to make the man pages for the selected rgbds version detectable by man-db.

How it works:
- Creates directory `$RGBENV_DEFAULT/man` -- this will get automatically searched by man-db, provided `$RGBENV_DEFAULT/bin` is in PATH.
- Selected rgbds directory is searched for pages (files with extensions matching the man section numbers).
	- This is a search (`find`) because different versions of rgbds have different pages, filenames, layouts, etc.
- The detected pages are symlinked to corresponding man section dir in `$RGBENV_DEFAULT/man/man{1,5,7}`

I've been installing man pages on Arch and Debian in this way for many years without an issue, but I'm not necessarily an expert on the topic. More to the point, I'm not aware of what exists outside of man-db and this is only intended to work with the automatic search path detection implemented by man-db.
In the case that this is executed on a system without man-db, there should be no consequence as all it does is create directories and symlinks within the rgbenv managed directory.

For reference, explanation of manpath search behaviour in [manpath(5) SEARCH PATH](https://man.archlinux.org/man/manpath.5.en#SEARCH_PATH). Notably:

> [...] man-db examines the user's `$PATH`.  For each `path_element` found there, [...] it adds all of `path_element/../man`, `path_element/man`, `path_element/../share/man`, and `path_element/share/man` that exist as directories to the search path.

Fixes #19 